### PR TITLE
 Add function for one key commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Goals:
 * Multiple Serial Ports callback methods
 * Custom Command termination default is `CR & LF`
 * Custom Arguments Delimeter default is `SPACE`
+* Optional _OneKey_ commands that are single characters without the need for
+    additional command termination
 
 ## SerialCommand object
 
@@ -33,6 +35,43 @@ void cmd_hello(SerialCommands* sender)
 
 SerialCommand cmd_hello_("hello", cmd_hello);
 ```
+
+### OneKey commands
+
+When sending commands from a keyboard, it is often useful to be able to use
+single keypresses to perform a specific action, like adjusting a motor speed up
+or down, for example.
+
+To make any command a _OneKey_ command, instantiate the command with a **single
+character** command string, and add `true` as a third argument:
+
+```c++
+SerialCommand cmd_faster("+", cmd_faster, true);
+SerialCommand cmd_slower("-", cmd_slower, true);
+```
+
+The `cmd_faster` and `cmd_slower` command functions has the same signature as
+for multiple character commands, except that arguments are not allowed for
+_OneKey_ commands (they don't make sense), so calling `sender->Next()` is not
+supported.
+
+_OneKey_ commands are only active when they come in as the _first_ character,
+either on startup, or after processing a previous command. In other words, if
+another command string contains a `+` like `set+go` for example, the command
+callback for the one key `+` command will not be called when `set+go` is
+entered, and the `set+go` command callback will be called as expected.
+
+Any multi character command that _starts_ with the same character as a one key
+command, will however never be activated as the one key command will always
+consume the single character command first, i.e:
+
+Multi char command: `up`  
+OneKey command: `u`
+
+The `up` command will never be executed since the `u` will be consumed by the
+one key command first, which leaves the `p` as the remainder for the command
+which will not match (unless of course there *is* in fact a `p` one key or multi char
+command).
 
 ## SerialCommands object
 

--- a/examples/SerialCommandsSimple/SerialCommandsOneKeySimple.ino
+++ b/examples/SerialCommandsSimple/SerialCommandsOneKeySimple.ino
@@ -1,0 +1,80 @@
+/*--------------------------------------------------------------------
+Author		: Pedro Pereira
+License		: BSD
+Repository	: https://github.com/ppedro74/Arduino-SerialCommands
+
+Modified    : Fitzterra <fitzterra@icave.net>
+            : to demonstrate usage of the one_key commands
+
+SerialCommands Simple Demo
+
+--------------------------------------------------------------------*/
+#include <Arduino.h>
+#include <SerialCommands.h>
+
+// Pin 13 has an LED connected on most Arduino boards.
+// Pin 11 has the LED on Teensy 2.0
+// Pin 6  has the LED on Teensy++ 2.0
+// Pin 13 has the LED on Teensy 3.0
+const int kLedPin = 13;
+
+char serial_command_buffer_[32];
+SerialCommands serial_commands_(&Serial, serial_command_buffer_, sizeof(serial_command_buffer_), "\r\n", " ");
+
+//This is the default handler, and gets called when no other command matches. 
+// Note: It does not get called for one_key commands that do not match
+void cmd_unrecognized(SerialCommands* sender, const char* cmd)
+{
+  sender->GetSerial()->print("Unrecognized command [");
+  sender->GetSerial()->print(cmd);
+  sender->GetSerial()->println("]");
+}
+
+//called for ON command, or one_key '1' command
+void cmd_led_on(SerialCommands* sender)
+{
+  digitalWrite(kLedPin, HIGH);  
+  sender->GetSerial()->println("Led is on");
+}
+
+//called for OFF command, or one_key '0' command
+void cmd_led_off(SerialCommands* sender)
+{
+  digitalWrite(kLedPin, LOW);  
+  sender->GetSerial()->println("Led is off");
+}
+
+//Note: Commands are case sensitive
+SerialCommand cmd_led_on_("ON", cmd_led_on);
+SerialCommand cmd_led_off_("OFF", cmd_led_off);
+// Add one_key commands to call the same on and off function but by simply
+// pressing '1' or '0' without needing a terminating key stroke.
+// One_key commands are ONLY tested when they are the first key pressed on
+// startup, or the first key after a previous terminating keystroke.
+SerialCommand cmd_led_on_ok_("1", cmd_led_on, true);
+SerialCommand cmd_led_off_ok_("0", cmd_led_off, true);
+
+
+void setup() 
+{
+  Serial.begin(115200);
+
+  //Configure the LED for output and sets the intial state to off
+  pinMode(kLedPin, OUTPUT);
+  digitalWrite(kLedPin, LOW);
+
+  serial_commands_.SetDefaultHandler(cmd_unrecognized);
+  serial_commands_.AddCommand(&cmd_led_on_);
+  serial_commands_.AddCommand(&cmd_led_off_);
+  serial_commands_.AddCommand(&cmd_led_on_ok_);
+  serial_commands_.AddCommand(&cmd_led_off_ok_);
+
+  Serial.println("Ready!");
+  Serial.println("\nLED On : type: 'ON' + press Enter, or only '1' without enter\n"
+                 "LED Off: type 'OFF' + press Enter, or only '0' without enter.\n");
+}
+
+void loop() 
+{
+  serial_commands_.ReadSerial();
+}

--- a/src/SerialCommands.h
+++ b/src/SerialCommands.h
@@ -24,22 +24,24 @@ typedef class SerialCommand SerialCommand;
 class SerialCommand
 {
 public:
-	SerialCommand(const char* cmd, void(*func)(SerialCommands*))
+	SerialCommand(const char* cmd, void(*func)(SerialCommands*), bool one_k=false)
 		: command(cmd),
 		function(func),
-		next(NULL)
+		next(NULL),
+		one_key(one_k)
 	{
 	}
 
 	const char* command;
 	void(*function)(SerialCommands*);
 	SerialCommand* next;
+	bool one_key;
 };
 
 class SerialCommands
 {
 public:
-	SerialCommands(Stream* serial, char* buffer, int16_t buffer_len, char* term = "\r\n", char* delim = " ") :
+	SerialCommands(Stream* serial, char* buffer, int16_t buffer_len, const char* term = "\r\n", const char* delim = " ") :
 		serial_(serial),
 		buffer_(buffer),
 		buffer_len_(buffer!=NULL && buffer_len > 0 ? buffer_len - 1 : 0), //string termination char '\0'
@@ -51,7 +53,10 @@ public:
 		term_pos_(0),
 		commands_head_(NULL),
 		commands_tail_(NULL),
-		commands_count_(0)
+		onek_cmds_head_(NULL),
+		onek_cmds_tail_(NULL),
+		commands_count_(0),
+		onek_cmds_count_(0)
 	{
 	}
 
@@ -106,15 +111,25 @@ private:
 	Stream* serial_;
 	char* buffer_;
 	int16_t buffer_len_;
-	char* term_;
-	char* delim_;
+	const char* term_;
+	const char* delim_;
 	void(*default_handler_)(SerialCommands*, const char*);
 	int16_t buffer_pos_;
 	char* last_token_;
 	int8_t term_pos_;
 	SerialCommand* commands_head_;
 	SerialCommand* commands_tail_;
+	SerialCommand* onek_cmds_head_;
+	SerialCommand* onek_cmds_tail_;
 	uint8_t commands_count_;
+	uint8_t onek_cmds_count_;
+
+	/**
+	 * \brief Tests for any one_key command and execute it if found
+	 * \return false if this was not a one_key command, true otherwise with
+	 *		   also clearing the buffer
+	 **/
+	bool CheckOneKeyCmd();
 };
 
 #endif


### PR DESCRIPTION
 The one_key functionality allows commands to be designated as "One Key"
 commands which means that if the command buffer is empty (no input keys
 received in a fresh buffer yet), and a character is then received that
 matched a "One Key" command, that command will be executed immediately
 without needing any command termination sequence.

 This is mainly useful when the serial input is from a human on a
 keyboard to do simple things like possibly adjusting volume or any
 other
 configuration value up or down by simple "one key" presses, instead of
 having to enter the command character and then press enter.

 Note that it re-uses the SerialCommand class as is and only adds one
 additional boolean to indicate if the command is a "one_key" command or
 not, default to false if not supplied.

 This means that although there is nothing stopping you from using a
 string value as a command for a "one_key" command, ONLY the first
 character in the string will be considered for the "one_key" command.