### PR TITLE
Add Arduino CLI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: Arduino_CI
+
+on: [push, pull_request]
+
+jobs:
+  arduino_ci:
+    name: "Arduino CI - OS(Ubuntu)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Arduino-CI/action@master


### PR DESCRIPTION
This Pull Request will create a GitHub workflow which will compile and test the library for a range of different Arduino boards.

This will point out improvement areas of the library for different boards and architectures.

Current implementation only shows the following errors when executing this workflow:
```bash
Compiling SerialCommandsArguments.ino for esp32:esp32:featheresp32:FlashFreq=80... 
Last command:  $  /usr/local/bin/arduino-cli --format json compile --fqbn esp32:esp32:featheresp32:FlashFreq=80 --warnings all --dry-run /github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'bool set_led(char*, int)':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:97:23: error: 'analogWrite' was not declared in this scope
   analogWrite(pin, pwm);
                       ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'void setup()':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:150:18: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  set_led("red", 0);
                  ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:151:20: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  set_led("green", 0);
                    ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:152:19: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
  set_led("blue", 0);
                   ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'bool set_led(char*, int)':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:100:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1plus: some warnings being treated as errors
Error during build: exit status 1
✗
Compiling SerialCommandsArguments.ino for esp8266:esp8266:huzzah:eesz=4M3M,xtal=80... 
Last command:  $  /usr/local/bin/arduino-cli --format json compile --fqbn esp8266:esp8266:huzzah:eesz=4M3M,xtal=80 --warnings all --dry-run /github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'void cmd_analog_read(SerialCommands*)':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:48:23: error: 'A1' was not declared in this scope
    value = analogRead(A1);
                       ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:51:23: error: 'A2' was not declared in this scope
    value = analogRead(A2);
                       ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'void setup()':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:150:18: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
  set_led("red", 0);
                  ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:151:20: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
  set_led("green", 0);
                    ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:152:19: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
  set_led("blue", 0);
                   ^
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino: In function 'bool set_led(char*, int)':
/github/home/Arduino/libraries/SerialCommands/examples/SerialCommandsArguments/SerialCommandsArguments.ino:100:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
Error during build: exit status 1
✗
```