### PR TITLE
Add type free pointer in SerialCommands to be used as context in commands callbacks

### DIFF
--- a/examples/SerialCommandsSimpleContext/SampleClass.cpp
+++ b/examples/SerialCommandsSimpleContext/SampleClass.cpp
@@ -1,0 +1,53 @@
+#include "SampleClass.hpp"
+#include <SerialCommands.h>
+#include <Arduino.h>
+
+char serial_command_buffer_[32];
+SerialCommands serial_commands_(&Serial, serial_command_buffer_,
+                                sizeof(serial_command_buffer_), "\r\n", " ");
+
+// This is the default handler, and gets called when no other command matches.
+void cmd_unrecognized(SerialCommands *sender, const char *cmd) {
+  sender->GetSerial()->print("Unrecognized command [");
+  sender->GetSerial()->print(cmd);
+  sender->GetSerial()->println("]");
+}
+
+// called for ON command
+void cmd_led_on(SerialCommands *sender) {
+
+  SampleClass *parent = static_cast<SampleClass *>(sender->context);
+  parent->ledOnCounter++;
+  sender->GetSerial()->print("Led was on ");
+  sender->GetSerial()->print(parent->ledOnCounter);
+  sender->GetSerial()->println("times");
+
+  digitalWrite(parent->ledPin, HIGH);
+  sender->GetSerial()->println("Led is on");
+}
+
+// called for OFF command
+void cmd_led_off(SerialCommands *sender) {
+  SampleClass *parent = static_cast<SampleClass *>(sender->context);
+  digitalWrite(parent->ledPin, LOW);
+  sender->GetSerial()->println("Led is off");
+}
+
+SampleClass::SampleClass(char ledPin) : ledPin(ledPin) {
+  
+    // Configure the LED for output and sets the intial state to off
+  pinMode(ledPin, OUTPUT);
+  digitalWrite(ledPin, LOW);
+  
+  ledOnCounter = 0;
+  serial_commands_.context = this;
+  serial_commands_.SetDefaultHandler(cmd_unrecognized);
+
+  SerialCommand cmd_led_on_("ON", cmd_led_on);
+  SerialCommand cmd_led_off_("OFF", cmd_led_off);
+
+  serial_commands_.AddCommand(&cmd_led_on_);
+  serial_commands_.AddCommand(&cmd_led_off_);
+}
+
+void SampleClass::loop() { serial_commands_.ReadSerial(); }

--- a/examples/SerialCommandsSimpleContext/SampleClass.hpp
+++ b/examples/SerialCommandsSimpleContext/SampleClass.hpp
@@ -1,0 +1,13 @@
+
+/*
+ * Class declaration does not mention SerialCommands, 
+ * hidden in implementation
+ */
+class SampleClass {
+
+public:
+  SampleClass(char ledPin);
+  void loop();
+  char ledOnCounter;
+  char ledPin;
+};

--- a/examples/SerialCommandsSimpleContext/SerialCommandsSimpleContext.ino
+++ b/examples/SerialCommandsSimpleContext/SerialCommandsSimpleContext.ino
@@ -1,0 +1,25 @@
+/*--------------------------------------------------------------------
+  Author    : Pedro Pereira
+  License   : BSD
+  Repository  : https://github.com/ppedro74/Arduino-SerialCommands
+
+  SerialCommands Simple Demo
+
+  --------------------------------------------------------------------*/
+#include <Arduino.h>
+#include "SampleClass.hpp"
+
+
+// Pin 13 has an LED connected on most Arduino boards.
+// Pin 11 has the LED on Teensy 2.0
+// Pin 6  has the LED on Teensy++ 2.0
+// Pin 13 has the LED on Teensy 3.0
+SampleClass sampleClass(13);
+
+void setup() {
+  Serial.begin(57600);
+
+  Serial.println("Ready!");
+}
+
+void loop() { sampleClass.loop(); }

--- a/src/SerialCommands.h
+++ b/src/SerialCommands.h
@@ -11,125 +11,114 @@ Repository	: https://github.com/ppedro74/Arduino-SerialCommands
 
 #include <Arduino.h>
 
-typedef enum ternary 
-{
-	SERIAL_COMMANDS_SUCCESS = 0,
-	SERIAL_COMMANDS_ERROR_NO_SERIAL,
-	SERIAL_COMMANDS_ERROR_BUFFER_FULL
+typedef enum ternary {
+  SERIAL_COMMANDS_SUCCESS = 0,
+  SERIAL_COMMANDS_ERROR_NO_SERIAL,
+  SERIAL_COMMANDS_ERROR_BUFFER_FULL
 } SERIAL_COMMANDS_ERRORS;
 
 class SerialCommands;
 
 typedef class SerialCommand SerialCommand;
-class SerialCommand
-{
+class SerialCommand {
 public:
-	SerialCommand(const char* cmd, void(*func)(SerialCommands*), bool one_k=false)
-		: command(cmd),
-		function(func),
-		next(NULL),
-		one_key(one_k)
-	{
-	}
+  SerialCommand(const char *cmd, void (*func)(SerialCommands *),
+                bool one_k = false)
+      : command(cmd), function(func), next(NULL), one_key(one_k) {}
 
-	const char* command;
-	void(*function)(SerialCommands*);
-	SerialCommand* next;
-	bool one_key;
+  const char *command;
+  void (*function)(SerialCommands *);
+  SerialCommand *next;
+  bool one_key;
 };
 
-class SerialCommands
-{
+class SerialCommands {
 public:
-	SerialCommands(Stream* serial, char* buffer, int16_t buffer_len, const char* term = "\r\n", const char* delim = " ") :
-		serial_(serial),
-		buffer_(buffer),
-		buffer_len_(buffer!=NULL && buffer_len > 0 ? buffer_len - 1 : 0), //string termination char '\0'
-		term_(term),
-		delim_(delim),
-		default_handler_(NULL),
-		buffer_pos_(0),
-		last_token_(NULL), 
-		term_pos_(0),
-		commands_head_(NULL),
-		commands_tail_(NULL),
-		onek_cmds_head_(NULL),
-		onek_cmds_tail_(NULL),
-		commands_count_(0),
-		onek_cmds_count_(0)
-	{
-	}
+  SerialCommands(Stream *serial, char *buffer, int16_t buffer_len,
+                 const char *term = "\r\n", const char *delim = " ")
+      : serial_(serial), buffer_(buffer),
+        buffer_len_(buffer != NULL && buffer_len > 0
+                        ? buffer_len - 1
+                        : 0), // string termination char '\0'
+        term_(term), delim_(delim), default_handler_(NULL), buffer_pos_(0),
+        last_token_(NULL), term_pos_(0), commands_head_(NULL),
+        commands_tail_(NULL), onek_cmds_head_(NULL), onek_cmds_tail_(NULL),
+        commands_count_(0), onek_cmds_count_(0) {}
 
+  /**
+   * \brief Adds a command handler (Uses a linked list)
+   * \param command
+   */
+  void AddCommand(SerialCommand *command);
 
-	/**
-	 * \brief Adds a command handler (Uses a linked list)
-	 * \param command 
-	 */
-	void AddCommand(SerialCommand* command);
+  /**
+   * \brief Checks the Serial port, reads the input buffer and calls a matching
+   * command handler. \return SERIAL_COMMANDS_SUCCESS when successful or
+   * SERIAL_COMMANDS_ERROR_XXXX on error.
+   */
+  SERIAL_COMMANDS_ERRORS ReadSerial();
 
-	/**
-	 * \brief Checks the Serial port, reads the input buffer and calls a matching command handler.
-	 * \return SERIAL_COMMANDS_SUCCESS when successful or SERIAL_COMMANDS_ERROR_XXXX on error.
-	 */
-	SERIAL_COMMANDS_ERRORS ReadSerial();
+  /**
+   * \brief Returns the source stream (Serial port)
+   * \return
+   */
+  Stream *GetSerial();
 
-	/**
-	 * \brief Returns the source stream (Serial port)
-	 * \return 
-	 */
-	Stream* GetSerial();
-	
-	/**
-	 * \brief Attaches a Serial Port to this object 
-	 * \param serial 
-	 */
-	void AttachSerial(Stream* serial);
-	
-	/**
-	 * \brief Detaches the serial port, if no serial port nothing will be done at ReadSerial
-	 */
-	void DetachSerial();
-	
-	/**
-	 * \brief Sets a default handler can be used for a catch all or unrecognized commands
-	 * \param function 
-	 */
-	void SetDefaultHandler(void(*function)(SerialCommands*, const char*));
-	
-	/**
-	 * \brief Clears the buffer, and resets the indexes.
-	 */
-	void ClearBuffer();
-	
-	/**
-	 * \brief Gets the next argument
-	 * \return returns NULL if no argument is available
-	 */
-	char* Next();
+  /**
+   * \brief Attaches a Serial Port to this object
+   * \param serial
+   */
+  void AttachSerial(Stream *serial);
+
+  /**
+   * \brief Detaches the serial port, if no serial port nothing will be done at
+   * ReadSerial
+   */
+  void DetachSerial();
+
+  /**
+   * \brief Sets a default handler can be used for a catch all or unrecognized
+   * commands \param function
+   */
+  void SetDefaultHandler(void (*function)(SerialCommands *, const char *));
+
+  /**
+   * \brief Clears the buffer, and resets the indexes.
+   */
+  void ClearBuffer();
+
+  /**
+   * \brief Gets the next argument
+   * \return returns NULL if no argument is available
+   */
+  char *Next();
+
+  /** type-free pointer passed to commands callbacks */
+  void *context;
 
 private:
-	Stream* serial_;
-	char* buffer_;
-	int16_t buffer_len_;
-	const char* term_;
-	const char* delim_;
-	void(*default_handler_)(SerialCommands*, const char*);
-	int16_t buffer_pos_;
-	char* last_token_;
-	int8_t term_pos_;
-	SerialCommand* commands_head_;
-	SerialCommand* commands_tail_;
-	SerialCommand* onek_cmds_head_;
-	SerialCommand* onek_cmds_tail_;
-	uint8_t commands_count_;
-	uint8_t onek_cmds_count_;
+  Stream *serial_;
+  char *buffer_;
+  int16_t buffer_len_;
+  const char *term_;
+  const char *delim_;
+  void (*default_handler_)(SerialCommands *, const char *);
+  int16_t buffer_pos_;
+  char *last_token_;
+  int8_t term_pos_;
+  SerialCommand *commands_head_;
+  SerialCommand *commands_tail_;
+  SerialCommand *onek_cmds_head_;
+  SerialCommand *onek_cmds_tail_;
+  uint8_t commands_count_;
+  uint8_t onek_cmds_count_;
 
-	/**
-	 * \brief Tests for any one_key command and execute it if found
-	 * \return false if this was not a one_key command, true otherwise with
-	 *		   also clearing the buffer
-	 **/
-	bool CheckOneKeyCmd();
+  /**
+   * \brief Tests for any one_key command and execute it if found
+   * \return false if this was not a one_key command, true otherwise with
+   *		   also clearing the buffer
+   **/
+  bool CheckOneKeyCmd();
 };
 
 #endif


### PR DESCRIPTION
Integration of current code in a OO projets is tedious. This PR provides a new attribute 'context', which does not break current implementation but allow to setup a parent class, for which attributes can be used in callbacks.