### PR TITLE
add support for processing arbitrary strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# SerialCommands
+# SerialCommands - MODIFIED
+This is a fork that allows you to inject arbitrary commands as if they were typed at the serial console. Useful if you want to use SerialCommands as a central dispatch for quick n dirty message processing from external sources (like MQTT/HTTP/etc)
+
 An Arduino library to tokenize and parse commands received over a serial port. 
 
 Inspired by (original version):

--- a/library.json
+++ b/library.json
@@ -2,16 +2,16 @@
     "name": "SerialCommands",
     "authors":
     {
-        "name": "Pedro Tiago Pereira",
+        "name": "Pedro Tiago Pereira (Original Author)",
         "email": "tiago.private@gmail.com",
         "url": "https://github.com/ppedro74"
     },
     "keywords": "serial, command, commands, cmd, parse, callback",
-    "description": "A Library to tokenize and parse commands received over a serial port. Simple and small memory footprint (no dynamic memory allocation)",
+    "description": "[forked] A Library to tokenize and parse commands received over a serial port. Simple and small memory footprint (no dynamic memory allocation)",
     "repository":
     {
         "type": "git",
-        "url": "https://github.com/ppedro74/Arduino-SerialCommands.git"
+        "url": "https://github.com/binary1230/Arduino-SerialCommands.git"
     },
     "version": "2.2.0",
     "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Pedro Tiago Pereira <tiago.private@gmail.com>
 sentence=An Arduino library to tokenize and parse commands received over a serial port. 
 paragraph=Simple, small footprint, no dynamic memory allocation
 category=Data Processing
-url=https://github.com/ppedro74/Arduino-SerialCommands
+url=https://github.com/binary1230/Arduino-SerialCommands
 architectures=*

--- a/src/SerialCommands.h
+++ b/src/SerialCommands.h
@@ -56,7 +56,8 @@ public:
 		onek_cmds_head_(NULL),
 		onek_cmds_tail_(NULL),
 		commands_count_(0),
-		onek_cmds_count_(0)
+		onek_cmds_count_(0),
+		is_processing_cmdline_(false)
 	{
 	}
 
@@ -107,6 +108,19 @@ public:
 	 */
 	char* Next();
 
+	/**
+		 * \brief Alternative input processing: Treat 'line' as if it was received from the Serial input.
+		 *        NOTE: Do NOT call this from inside any command handler, it will return false
+		 *        This disregards anything currently being typed in via real serial, and clears the buffer afterwards.
+         *        Will not call OneKey commands, only regular commands.
+         *        'line' must be a null-terminated string
+         *        it should be no more than the initial buffer size minus 1
+		 *        'line' should not end in any delimiters (like newline/etc), just type the string you want.
+         *        example: ProcessCommandLine("set wifi_ssid my_network_name");
+		 * \ return True if successful, false if error (string too low, buffer too small to hold command, or, recursive call detected from cmd handler)
+		 */
+	bool ProcessCommandLine(const char* line);
+
 private:
 	Stream* serial_;
 	char* buffer_;
@@ -123,6 +137,7 @@ private:
 	SerialCommand* onek_cmds_tail_;
 	uint8_t commands_count_;
 	uint8_t onek_cmds_count_;
+	bool is_processing_cmdline_;
 
 	/**
 	 * \brief Tests for any one_key command and execute it if found
@@ -130,6 +145,8 @@ private:
 	 *		   also clearing the buffer
 	 **/
 	bool CheckOneKeyCmd();
+
+	void ProcessBuffer();
 };
 
 #endif


### PR DESCRIPTION
- call new ProcessCommandLine(str) with a command to run it through the same processor, as if it was sent via Serial
- useful if you want to test or inject other command input via this system for dispatching

I might want to run this over with a fine-tooth comb before submitting but, seems to be ok. If useful feel free to merge

TODO:
- [ ] remove readme/docs modifications